### PR TITLE
Make CI Pipeline more generic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: Build
 on:
   workflow_call:
 
+env:
+  FMU_FILE_NAME: HelloWorldSensor.fmu #TODO: Adjust to file name of your FMU
+
 jobs:
   build:
     name: Build FMU
@@ -51,7 +54,7 @@ jobs:
 
     - name: Copy Model FMU
       working-directory: build
-      run: cp HelloWorldSensor.fmu /tmp/model_fmu/HelloWorldSensor.fmu
+      run: cp $FMU_FILE_NAME /tmp/model_fmu/SensorModel.fmu
 
     - name: Cache Model FMU
       id: cache-model-fmu

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # SL-1-0 Sensor Model Repository Template
 
-< GitHub Action Badges of CI Pipeline. The pipeline is further described [here](https://github.com/openMSL/sensor_model_testing/blob/main/doc/test_architecture.md)>
+< GitHub Action Badges of CI Pipeline.
+The pipeline is further described [here](https://github.com/openMSL/sensor_model_testing/blob/main/doc/test_architecture.md)
+To use the CI pipeline after clopying this template, you just have to change the file name of your model FMU (env: FMU_FILE_NAME) in [build.yml](.github/workflows/build.yml)>
 
 [![Credibility Assessment Level 0](../../actions/workflows/cl0.yml/badge.svg)](https://github.com/openMSL/sl-1-5-sensor-model-testing/blob/main/doc/test_architecture.md#cl-0-license-check)
 [![Credibility Assessment Level 1](../../actions/workflows/cl1.yml/badge.svg)](https://github.com/openMSL/sl-1-5-sensor-model-testing/blob/main/doc/test_architecture.md#cl-1-code-verification)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 < GitHub Action Badges of CI Pipeline.
 The pipeline is further described [here](https://github.com/openMSL/sensor_model_testing/blob/main/doc/test_architecture.md)
-To use the CI pipeline after clopying this template, you just have to change the file name of your model FMU (env: FMU_FILE_NAME) in [build.yml](.github/workflows/build.yml)>
+To use the CI pipeline after copying this template, you just have to change the file name of your model FMU (env: FMU_FILE_NAME) in [build.yml](.github/workflows/build.yml)>
 
 [![Credibility Assessment Level 0](../../actions/workflows/cl0.yml/badge.svg)](https://github.com/openMSL/sl-1-5-sensor-model-testing/blob/main/doc/test_architecture.md#cl-0-license-check)
 [![Credibility Assessment Level 1](../../actions/workflows/cl1.yml/badge.svg)](https://github.com/openMSL/sl-1-5-sensor-model-testing/blob/main/doc/test_architecture.md#cl-1-code-verification)

--- a/test/integration/001_smoke_test/SystemStructure.ssd
+++ b/test/integration/001_smoke_test/SystemStructure.ssd
@@ -41,7 +41,7 @@
                     </ssd:ParameterBinding>
                 </ssd:ParameterBindings>
             </ssd:Component>
-            <ssd:Component type="application/x-fmu-sharedlibrary" source="/tmp/model_fmu/HelloWorldSensor.fmu" implementation="CoSimulation" name="HelloWorldSensor" description="">
+            <ssd:Component type="application/x-fmu-sharedlibrary" source="/tmp/model_fmu/SensorModel.fmu" implementation="CoSimulation" name="SensorModel" description="">
                 <ssd:Connectors>
                     <ssd:Connector name="OSMPSensorDataOut.base.hi" kind="output">
                         <ssc:Integer/>
@@ -81,9 +81,9 @@
             </ssd:Component>
         </ssd:Elements>
         <ssd:Connections>
-            <ssd:Connection startElement="OSMPTraceFilePlayer" startConnector="OSMPSensorViewOut.base.hi" endElement="HelloWorldSensor" endConnector="OSMPSensorViewIn.base.hi" suppressUnitConversion="false"/>
-            <ssd:Connection startElement="OSMPTraceFilePlayer" startConnector="OSMPSensorViewOut.size" endElement="HelloWorldSensor" endConnector="OSMPSensorViewIn.size" suppressUnitConversion="false"/>
-            <ssd:Connection startElement="OSMPTraceFilePlayer" startConnector="OSMPSensorViewOut.base.lo" endElement="HelloWorldSensor" endConnector="OSMPSensorViewIn.base.lo" suppressUnitConversion="false"/>
+            <ssd:Connection startElement="OSMPTraceFilePlayer" startConnector="OSMPSensorViewOut.base.hi" endElement="SensorModel" endConnector="OSMPSensorViewIn.base.hi" suppressUnitConversion="false"/>
+            <ssd:Connection startElement="OSMPTraceFilePlayer" startConnector="OSMPSensorViewOut.size" endElement="SensorModel" endConnector="OSMPSensorViewIn.size" suppressUnitConversion="false"/>
+            <ssd:Connection startElement="OSMPTraceFilePlayer" startConnector="OSMPSensorViewOut.base.lo" endElement="SensorModel" endConnector="OSMPSensorViewIn.base.lo" suppressUnitConversion="false"/>
         </ssd:Connections>
         <ssd:SystemGeometry x1="-619.0" y1="-666.5" x2="1849.5" y2="126.5"/>
     </ssd:System>

--- a/test/integration/002_output_osi_fields/SystemStructure.ssd
+++ b/test/integration/002_output_osi_fields/SystemStructure.ssd
@@ -41,7 +41,7 @@
                     </ssd:ParameterBinding>
                 </ssd:ParameterBindings>
             </ssd:Component>
-            <ssd:Component type="application/x-fmu-sharedlibrary" source="/tmp/model_fmu/HelloWorldSensor.fmu" implementation="CoSimulation" name="HelloWorldSensor" description="">
+            <ssd:Component type="application/x-fmu-sharedlibrary" source="/tmp/model_fmu/SensorModel.fmu" implementation="CoSimulation" name="SensorModel" description="">
                 <ssd:Connectors>
                     <ssd:Connector name="OSMPSensorDataOut.base.hi" kind="output">
                         <ssc:Integer/>
@@ -123,12 +123,12 @@
             </ssd:Component>
         </ssd:Elements>
         <ssd:Connections>
-            <ssd:Connection startElement="OSMPTraceFilePlayer" startConnector="OSMPSensorViewOut.base.hi" endElement="HelloWorldSensor" endConnector="OSMPSensorViewIn.base.hi" suppressUnitConversion="false"/>
-            <ssd:Connection startElement="OSMPTraceFilePlayer" startConnector="OSMPSensorViewOut.size" endElement="HelloWorldSensor" endConnector="OSMPSensorViewIn.size" suppressUnitConversion="false"/>
-            <ssd:Connection startElement="OSMPTraceFilePlayer" startConnector="OSMPSensorViewOut.base.lo" endElement="HelloWorldSensor" endConnector="OSMPSensorViewIn.base.lo" suppressUnitConversion="false"/>
-            <ssd:Connection startElement="HelloWorldSensor" startConnector="OSMPSensorDataOut.base.hi" endElement="OSIFieldChecker" endConnector="OSMPSensorDataIn.base.hi" suppressUnitConversion="false"/>
-            <ssd:Connection startElement="HelloWorldSensor" startConnector="OSMPSensorDataOut.size" endElement="OSIFieldChecker" endConnector="OSMPSensorDataIn.size" suppressUnitConversion="false"/>
-            <ssd:Connection startElement="HelloWorldSensor" startConnector="OSMPSensorDataOut.base.lo" endElement="OSIFieldChecker" endConnector="OSMPSensorDataIn.base.lo" suppressUnitConversion="false"/>
+            <ssd:Connection startElement="OSMPTraceFilePlayer" startConnector="OSMPSensorViewOut.base.hi" endElement="SensorModel" endConnector="OSMPSensorViewIn.base.hi" suppressUnitConversion="false"/>
+            <ssd:Connection startElement="OSMPTraceFilePlayer" startConnector="OSMPSensorViewOut.size" endElement="SensorModel" endConnector="OSMPSensorViewIn.size" suppressUnitConversion="false"/>
+            <ssd:Connection startElement="OSMPTraceFilePlayer" startConnector="OSMPSensorViewOut.base.lo" endElement="SensorModel" endConnector="OSMPSensorViewIn.base.lo" suppressUnitConversion="false"/>
+            <ssd:Connection startElement="SensorModel" startConnector="OSMPSensorDataOut.base.hi" endElement="OSIFieldChecker" endConnector="OSMPSensorDataIn.base.hi" suppressUnitConversion="false"/>
+            <ssd:Connection startElement="SensorModel" startConnector="OSMPSensorDataOut.size" endElement="OSIFieldChecker" endConnector="OSMPSensorDataIn.size" suppressUnitConversion="false"/>
+            <ssd:Connection startElement="SensorModel" startConnector="OSMPSensorDataOut.base.lo" endElement="OSIFieldChecker" endConnector="OSMPSensorDataIn.base.lo" suppressUnitConversion="false"/>
         </ssd:Connections>
         <ssd:SystemGeometry x1="-619.0" y1="-666.5" x2="1849.5" y2="126.5"/>
     </ssd:System>


### PR DESCRIPTION
**Add a description**
Currently, there are a couple of places in the CI pipeline that have to be adapted to a new model, when the template is used. This PR introduces an FMU_FILE_NAME variable in build pipeline, so only this variable has to be adapted when using the template. Everything else is now generic.

**Take this checklist as orientation for yourself, if this PR is ready for Maintainer Review**
- [x] My suggestion follows the [governance rules](https://github.com/openMSL/governance-and-documentation).
- [x] All commits of this PR are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] My changes generate no errors when passing CI tests. 
- [x] I updated all documentation (readmes incl. figures) according to my changes.
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.