### PR TITLE
Store built FMU as artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,6 @@ name: Build
 on:
   workflow_call:
 
-env:
-  FMU_FILE_NAME: HelloWorldSensor.fmu #TODO: Adjust to file name of your FMU
-
 jobs:
   build:
     name: Build FMU
@@ -54,7 +51,7 @@ jobs:
 
     - name: Copy Model FMU
       working-directory: build
-      run: cp $FMU_FILE_NAME /tmp/model_fmu/SensorModel.fmu
+      run: cp ${{ github.event.repository.name }}.fmu /tmp/model_fmu/${{ github.event.repository.name }}.fmu
 
     - name: Cache Model FMU
       id: cache-model-fmu

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
-    - name: Try get name of repo
-      run: echo "${{ github.event.repository.name }}"
-
     - name: Checkout Model
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
+    - name: Try get name of repo
+      run: echo "${{ github.event.repository.name }}"
+
     - name: Checkout Model
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/cl1.yml
+++ b/.github/workflows/cl1.yml
@@ -11,6 +11,10 @@ jobs:
     name: Build Model
     uses: ./.github/workflows/build.yml
 
+  fmu-artifact:
+    name: Build Model
+    uses: ./.github/workflows/fmu_artifact.yml
+
   cpp-linter:
     name: C++ Linter
     uses: ./.github/workflows/cpp-linter.yml

--- a/.github/workflows/cl1.yml
+++ b/.github/workflows/cl1.yml
@@ -12,7 +12,8 @@ jobs:
     uses: ./.github/workflows/build.yml
 
   fmu-artifact:
-    name: Build Model
+    needs: build_model
+    name: FMU Artifact
     uses: ./.github/workflows/fmu_artifact.yml
 
   cpp-linter:

--- a/.github/workflows/fmu_artifact.yml
+++ b/.github/workflows/fmu_artifact.yml
@@ -1,0 +1,23 @@
+name: Archive built FMU as artifact
+
+on:
+  workflow_call:
+
+jobs:
+  fmu-artifact:
+    name: Output FMU as artifact
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Cache Model FMU
+      id: cache-model-fmu
+      uses: actions/cache@v3
+      with:
+        path: /tmp/model_fmu
+        key: ${{ runner.os }}-model-fmu
+
+    - name: Archive built FMU
+      uses: actions/upload-artifact@v3
+      with:
+        name: SensorModel.fmu
+        path: /tmp/model_fmu/SensorModel.fmu

--- a/.github/workflows/fmu_artifact.yml
+++ b/.github/workflows/fmu_artifact.yml
@@ -16,8 +16,11 @@ jobs:
         path: /tmp/model_fmu
         key: ${{ runner.os }}-model-fmu
 
+    - name: Rename FMU
+      run: cp /tmp/model_fmu/SensorModel.fmu /tmp/${GITHUB_REPOSITORY#*/}.fmu
+
     - name: Archive built FMU
       uses: actions/upload-artifact@v3
       with:
-        name: SensorModel.fmu
-        path: /tmp/model_fmu/SensorModel.fmu
+        name: ${GITHUB_REPOSITORY#*/}
+        path: /tmp/${GITHUB_REPOSITORY#*/}.fmu

--- a/.github/workflows/fmu_artifact.yml
+++ b/.github/workflows/fmu_artifact.yml
@@ -16,11 +16,8 @@ jobs:
         path: /tmp/model_fmu
         key: ${{ runner.os }}-model-fmu
 
-    - name: Rename FMU
-      run: cp /tmp/model_fmu/SensorModel.fmu /tmp/${{ github.event.repository.name }}.fmu
-
     - name: Archive built FMU
       uses: actions/upload-artifact@v3
       with:
         name: ${{ github.event.repository.name }}
-        path: /tmp/${{ github.event.repository.name }}.fmu
+        path: /tmp/model_fmu/${{ github.event.repository.name }}.fmu

--- a/.github/workflows/fmu_artifact.yml
+++ b/.github/workflows/fmu_artifact.yml
@@ -17,10 +17,10 @@ jobs:
         key: ${{ runner.os }}-model-fmu
 
     - name: Rename FMU
-      run: cp /tmp/model_fmu/SensorModel.fmu /tmp/${GITHUB_REPOSITORY#*/}.fmu
+      run: cp /tmp/model_fmu/SensorModel.fmu /tmp/${{ github.event.repository.name }}.fmu
 
     - name: Archive built FMU
       uses: actions/upload-artifact@v3
       with:
-        name: ${GITHUB_REPOSITORY#*/}
-        path: /tmp/${GITHUB_REPOSITORY#*/}.fmu
+        name: ${{ github.event.repository.name }}
+        path: /tmp/${{ github.event.repository.name }}.fmu

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # SL-1-0 Sensor Model Repository Template
 
 < GitHub Action Badges of CI Pipeline.
-The pipeline is further described [here](https://github.com/openMSL/sensor_model_testing/blob/main/doc/test_architecture.md)
-To use the CI pipeline after copying this template, you just have to change the file name of your model FMU (env: FMU_FILE_NAME) in [build.yml](.github/workflows/build.yml)>
+The pipeline is further described [here](https://github.com/openMSL/sensor_model_testing/blob/main/doc/test_architecture.md)>
 
 [![Credibility Assessment Level 0](../../actions/workflows/cl0.yml/badge.svg)](https://github.com/openMSL/sl-1-5-sensor-model-testing/blob/main/doc/test_architecture.md#cl-0-license-check)
 [![Credibility Assessment Level 1](../../actions/workflows/cl1.yml/badge.svg)](https://github.com/openMSL/sl-1-5-sensor-model-testing/blob/main/doc/test_architecture.md#cl-1-code-verification)
@@ -88,6 +87,8 @@ The following is an example for building a model as an FMU in Ubuntu.
     ```
 
 3. Take FMU from `FMU_INSTALL_DIR`
+
+< The final FMU has to be named according to the repository name. In this example sl-1-0-sensor-model-repository-template.fmu >
 
 ## Credits
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,4 +47,4 @@ add_custom_command(TARGET HelloWorldSensor
 		COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/HelloWorldSensor.cpp" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/sources/"
 		COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/HelloWorldSensor.h" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/sources/"
 		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:HelloWorldSensor> $<$<PLATFORM_ID:Windows>:$<$<CONFIG:Debug>:$<TARGET_PDB_FILE:HelloWorldSensor>>> "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/binaries/${FMI_BINARIES_PLATFORM}"
-		COMMAND ${CMAKE_COMMAND} -E chdir "${CMAKE_CURRENT_BINARY_DIR}/buildfmu" ${CMAKE_COMMAND} -E tar "cfv" "${FMU_INSTALL_DIR}/HelloWorldSensor.fmu" --format=zip "modelDescription.xml" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/sources" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/binaries/${FMI_BINARIES_PLATFORM}")
+		COMMAND ${CMAKE_COMMAND} -E chdir "${CMAKE_CURRENT_BINARY_DIR}/buildfmu" ${CMAKE_COMMAND} -E tar "cfv" "${FMU_INSTALL_DIR}/sl-1-0-sensor-model-repository-template.fmu" --format=zip "modelDescription.xml" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/sources" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/binaries/${FMI_BINARIES_PLATFORM}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,13 +9,13 @@ string(MD5 FMUGUID modelDescription.in.xml)
 configure_file(modelDescription.in.xml modelDescription.xml @ONLY)
 
 find_package(Protobuf 2.6.1 REQUIRED)
-add_library(HelloWorldSensor SHARED HelloWorldSensor.cpp HelloWorldSensor.h)
-set_target_properties(HelloWorldSensor PROPERTIES PREFIX "")
-target_compile_definitions(HelloWorldSensor PRIVATE "FMU_SHARED_OBJECT")
+add_library(sl-1-0-sensor-model-repository-template SHARED HelloWorldSensor.cpp HelloWorldSensor.h)
+set_target_properties(sl-1-0-sensor-model-repository-template PROPERTIES PREFIX "")
+target_compile_definitions(sl-1-0-sensor-model-repository-template PRIVATE "FMU_SHARED_OBJECT")
 if(LINK_WITH_SHARED_OSI)
-	target_link_libraries(HelloWorldSensor open_simulation_interface)
+	target_link_libraries(sl-1-0-sensor-model-repository-template open_simulation_interface)
 else()
-	target_link_libraries(HelloWorldSensor open_simulation_interface_pic)
+	target_link_libraries(sl-1-0-sensor-model-repository-template open_simulation_interface_pic)
 endif()
 
 if(WIN32)
@@ -38,7 +38,7 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 	endif()
 endif()
 
-add_custom_command(TARGET HelloWorldSensor
+add_custom_command(TARGET sl-1-0-sensor-model-repository-template
 		POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E remove_directory "${CMAKE_CURRENT_BINARY_DIR}/buildfmu"
 		COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/sources"
@@ -46,5 +46,5 @@ add_custom_command(TARGET HelloWorldSensor
 		COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/modelDescription.xml" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu"
 		COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/HelloWorldSensor.cpp" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/sources/"
 		COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/HelloWorldSensor.h" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/sources/"
-		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:HelloWorldSensor> $<$<PLATFORM_ID:Windows>:$<$<CONFIG:Debug>:$<TARGET_PDB_FILE:HelloWorldSensor>>> "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/binaries/${FMI_BINARIES_PLATFORM}"
+		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:sl-1-0-sensor-model-repository-template> $<$<PLATFORM_ID:Windows>:$<$<CONFIG:Debug>:$<TARGET_PDB_FILE:sl-1-0-sensor-model-repository-template>>> "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/binaries/${FMI_BINARIES_PLATFORM}"
 		COMMAND ${CMAKE_COMMAND} -E chdir "${CMAKE_CURRENT_BINARY_DIR}/buildfmu" ${CMAKE_COMMAND} -E tar "cfv" "${FMU_INSTALL_DIR}/sl-1-0-sensor-model-repository-template.fmu" --format=zip "modelDescription.xml" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/sources" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/binaries/${FMI_BINARIES_PLATFORM}")

--- a/src/modelDescription.in.xml
+++ b/src/modelDescription.in.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <fmiModelDescription
   fmiVersion="2.0"
-  modelName="Hello World Sensor"
+  modelName="sl-1-0-sensor-model-repository-template"
   guid="@FMUGUID@"
   description="Demonstration C++ Sensor FMU for OSI Sensor Model Packaging within OpenMSL"
   author="Persival GmbH"
@@ -10,7 +10,7 @@
   generationDateAndTime="@FMUTIMESTAMP@"
   variableNamingConvention="structured">
   <CoSimulation
-    modelIdentifier="HelloWorldSensor"
+    modelIdentifier="sl-1-0-sensor-model-repository-template"
     canHandleVariableCommunicationStepSize="true"
     canNotUseMemoryManagementFunctions="true">
     <SourceFiles>

--- a/test/integration/001_smoke_test_tracefile/SystemStructure.ssd
+++ b/test/integration/001_smoke_test_tracefile/SystemStructure.ssd
@@ -41,7 +41,7 @@
                     </ssd:ParameterBinding>
                 </ssd:ParameterBindings>
             </ssd:Component>
-            <ssd:Component type="application/x-fmu-sharedlibrary" source="/tmp/model_fmu/SensorModel.fmu" implementation="CoSimulation" name="SensorModel" description="">
+            <ssd:Component type="application/x-fmu-sharedlibrary" source="/tmp/model_fmu/sl-1-0-sensor-model-repository-template.fmu" implementation="CoSimulation" name="SensorModel" description="">
                 <ssd:Connectors>
                     <ssd:Connector name="OSMPSensorDataOut.base.hi" kind="output">
                         <ssc:Integer/>

--- a/test/integration/002_smoke_test_scenario/SystemStructure.ssd
+++ b/test/integration/002_smoke_test_scenario/SystemStructure.ssd
@@ -44,7 +44,7 @@
                     </ssd:ParameterBinding>
                 </ssd:ParameterBindings>
             </ssd:Component>
-            <ssd:Component type="application/x-fmu-sharedlibrary" source="/tmp/model_fmu/SensorModel.fmu" implementation="CoSimulation" name="SensorModel" description="">
+            <ssd:Component type="application/x-fmu-sharedlibrary" source="/tmp/model_fmu/sl-1-0-sensor-model-repository-template.fmu" implementation="CoSimulation" name="SensorModel" description="">
                 <ssd:Connectors>
                     <ssd:Connector name="OSMPSensorDataOut.base.hi" kind="output">
                         <ssc:Integer/>

--- a/test/integration/003_output_osi_fields/SystemStructure.ssd
+++ b/test/integration/003_output_osi_fields/SystemStructure.ssd
@@ -41,7 +41,7 @@
                     </ssd:ParameterBinding>
                 </ssd:ParameterBindings>
             </ssd:Component>
-            <ssd:Component type="application/x-fmu-sharedlibrary" source="/tmp/model_fmu/SensorModel.fmu" implementation="CoSimulation" name="SensorModel" description="">
+            <ssd:Component type="application/x-fmu-sharedlibrary" source="/tmp/model_fmu/sl-1-0-sensor-model-repository-template.fmu" implementation="CoSimulation" name="SensorModel" description="">
                 <ssd:Connectors>
                     <ssd:Connector name="OSMPSensorDataOut.base.hi" kind="output">
                         <ssc:Integer/>

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -7,5 +7,5 @@ include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
 # 'Google_Tests_run' is the target name
 # 'test1.cpp tests2.cpp' are source files with tests
 add_executable(Google_Tests_run test.cpp)
-target_link_libraries(Google_Tests_run HelloWorldSensor)
+target_link_libraries(Google_Tests_run sl-1-0-sensor-model-repository-template)
 target_link_libraries(Google_Tests_run gtest gtest_main)


### PR DESCRIPTION
**Add a description**
The model is build in the pipeline. For others to access the already built fmu, it is stored in an action artifact, so it can be downloaded.

**Take this checklist as orientation for yourself, if this PR is ready for Maintainer Review**
- [x] My suggestion follows the [governance rules](https://github.com/openMSL/governance-and-documentation).
- [x] All commits of this PR are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] My changes generate no errors when passing CI tests. 
- [x] I updated all documentation (readmes incl. figures) according to my changes.
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.
