### PR TITLE
Integrate all credibility assessment levels into one pipeline

### DIFF
--- a/.github/workflows/cl0.yml
+++ b/.github/workflows/cl0.yml
@@ -1,4 +1,4 @@
-name: CL 0
+name: Credibility Assessment Level 0
 
 on:
   workflow_call:

--- a/.github/workflows/cl0.yml
+++ b/.github/workflows/cl0.yml
@@ -1,4 +1,4 @@
-name: Credibility Assessment Level 0
+name: CL 0
 
 on:
   workflow_call:

--- a/.github/workflows/cl0.yml
+++ b/.github/workflows/cl0.yml
@@ -1,10 +1,7 @@
 name: Credibility Assessment Level 0
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  workflow_call:
 
 jobs:
   check-spdx-headers:

--- a/.github/workflows/cl1.yml
+++ b/.github/workflows/cl1.yml
@@ -1,11 +1,11 @@
-name: Credibility Assessment Level 1
+name: CL 1
 
 on:
   workflow_call:
 
 jobs:
   build_model:
-    name: Build Model
+    #name: Build Model
     uses: ./.github/workflows/build.yml
 
   fmu-artifact:

--- a/.github/workflows/cl1.yml
+++ b/.github/workflows/cl1.yml
@@ -1,10 +1,7 @@
 name: Credibility Assessment Level 1
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  workflow_call:
 
 jobs:
   build_model:

--- a/.github/workflows/cl1.yml
+++ b/.github/workflows/cl1.yml
@@ -1,11 +1,11 @@
-name: CL 1
+name: Credibility Assessment Level 1
 
 on:
   workflow_call:
 
 jobs:
   build_model:
-    #name: Build Model
+    name: Build Model
     uses: ./.github/workflows/build.yml
 
   fmu-artifact:

--- a/.github/workflows/cl2.yml
+++ b/.github/workflows/cl2.yml
@@ -35,7 +35,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 
   run_integration_test:
-    needs: [build_model, build_tracefile_player, build_openmcx, build_osi_field_checker_fmu, build_esmini, generate_integration_test_paths]
+    needs: [build_tracefile_player, build_openmcx, build_osi_field_checker_fmu, build_esmini, generate_integration_test_paths]
     name: Integration Test
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/cl2.yml
+++ b/.github/workflows/cl2.yml
@@ -1,16 +1,9 @@
 name: Credibility Assessment Level 2
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  workflow_call:
 
 jobs:
-  build_model:
-    name: Build Model
-    uses: ./.github/workflows/build.yml
-
   build_tracefile_player:
     name: Build Tracefile Player FMU
     uses: ./.github/workflows/build_tracefile_player.yml

--- a/.github/workflows/cl2.yml
+++ b/.github/workflows/cl2.yml
@@ -1,4 +1,4 @@
-name: CL 2
+name: Credibility Assessment Level 2
 
 on:
   workflow_call:

--- a/.github/workflows/cl2.yml
+++ b/.github/workflows/cl2.yml
@@ -1,4 +1,4 @@
-name: Credibility Assessment Level 2
+name: CL 2
 
 on:
   workflow_call:

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   cpp-linter:
+    name: C++ Linter
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Model

--- a/.github/workflows/fmu_artifact.yml
+++ b/.github/workflows/fmu_artifact.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   fmu-artifact:
-    name: Output FMU as artifact
+    name: FMU Artifact
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   markdown-lint:
+    name: Markdown Linter
     runs-on: ubuntu-latest
     steps:
     - name: checkout

--- a/.github/workflows/srmd-validator.yml
+++ b/.github/workflows/srmd-validator.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   srmd-validator:
+    name: SRMD Validator
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -8,14 +8,14 @@ on:
 
 jobs:
   cl0:
-    name: Credibility Assessment Level 0
+    name: CL 0
     uses: ./.github/workflows/cl0.yml
 
   cl1:
-    name: Credibility Assessment Level 1
+    name: CL 1
     uses: ./.github/workflows/cl1.yml
 
   cl2:
-    name: Credibility Assessment Level 2
+    name: CL 2
     needs: cl1
     uses: ./.github/workflows/cl2.yml

--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -1,0 +1,21 @@
+name: Test Pipeline
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  cl0:
+    name: Credibility Assessment Level 0
+    uses: ./.github/workflows/cl0.yml
+
+  cl1:
+    name: Credibility Assessment Level 1
+    uses: ./.github/workflows/cl1.yml
+
+  cl2:
+    name: Credibility Assessment Level 2
+    needs: cl1
+    uses: ./.github/workflows/cl2.yml

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Check unit tests exist
       id: check_files
-      uses: andstor/file-existence-action@v1
+      uses: andstor/file-existence-action@v2
       with:
         files: "test/unit"
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   unit-tests:
+    name: Unit Tests
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Model


### PR DESCRIPTION
**Add a description**
Restructure GitHub workflows to integrate all credibility assessment levels into one test pipeline.

**Take this checklist as orientation for yourself, if this PR is ready for Maintainer Review**
- [x] My suggestion follows the [governance rules](https://github.com/openMSL/governance-and-documentation).
- [x] All commits of this PR are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] My changes generate no errors when passing CI tests. 
- [ ] I updated all documentation (readmes incl. figures) according to my changes.
- [x] I have successfully implemented and tested my fix/feature locally.
- [ ] Appropriate reviewer(s) are assigned.
