### PR TITLE
Output Commit ID of Used Tools in Pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,3 +59,8 @@ jobs:
       with:
         path: /tmp/model_fmu
         key: ${{ runner.os }}-model-fmu
+
+    - name: Commit ID
+      run: |
+        echo "Commit ID: "
+        echo $(git rev-parse --short HEAD)

--- a/.github/workflows/build_esmini.yml
+++ b/.github/workflows/build_esmini.yml
@@ -58,7 +58,20 @@ jobs:
         if: steps.cache-esmini-fmu.outputs.cache-hit != 'true'
         run: mkdir /tmp/esmini_fmu
 
+      - name: Copy Commit ID to Cache
+        if: steps.cache-esmini-fmu.outputs.cache-hit != 'true'
+        working-directory: esmini
+        run: |
+          git rev-parse --short HEAD > commit-id.txt
+          cp commit-id.txt /tmp/esmini_fmu/commit-id.txt
+
       - name: Copy esmini FMU
         if: steps.cache-esmini-fmu.outputs.cache-hit != 'true'
         working-directory: esmini/OSMP_FMU/build
         run: cp EsminiOsiSource.fmu /tmp/esmini_fmu/EsminiOsiSource.fmu
+
+      - name: Commit ID
+        working-directory: /tmp/esmini_fmu
+        run: |
+          echo "Commit ID: "
+          echo $(cat commit-id.txt)

--- a/.github/workflows/build_openmcx.yml
+++ b/.github/workflows/build_openmcx.yml
@@ -23,7 +23,18 @@ jobs:
         if: steps.cache-openmcx.outputs.cache-hit != 'true'
         run: git clone https://github.com/eclipse/openmcx.git
 
+      - name: Copy Commit ID to Cache
+        if: steps.cache-openmcx.outputs.cache-hit != 'true'
+        working-directory: openmcx
+        run: git rev-parse --short HEAD > commit-id.txt
+
       - name: Build OpenMCx
         if: steps.cache-openmcx.outputs.cache-hit != 'true'
         working-directory: openmcx
         run: ./build.sh
+
+      - name: Commit ID
+        working-directory: openmcx
+        run: |
+          echo "Commit ID: "
+          echo $(cat commit-id.txt)

--- a/.github/workflows/build_osi_field_checker.yml
+++ b/.github/workflows/build_osi_field_checker.yml
@@ -72,6 +72,8 @@ jobs:
         working-directory: sl-1-5-sensor-model-testing/build
         run: cp OSIFieldChecker.fmu /tmp/osi-field-checker/OSIFieldChecker.fmu
 
-      - name: esmini Commit ID
+      - name: Commit ID
         working-directory: /tmp/osi-field-checker
-        run: echo $(cat commit-id.txt)
+        run: |
+          echo "Commit ID: "
+          echo $(cat commit-id.txt)

--- a/.github/workflows/build_osi_field_checker.yml
+++ b/.github/workflows/build_osi_field_checker.yml
@@ -60,7 +60,18 @@ jobs:
         working-directory: sl-1-5-sensor-model-testing/build
         run: mkdir /tmp/osi-field-checker
 
+      - name: Copy Commit ID to Cache
+        if: steps.cache-esmini-fmu.outputs.cache-hit != 'true'
+        working-directory: sl-1-5-sensor-model-testing
+        run: |
+          git rev-parse --short HEAD > commit-id.txt
+          cp commit-id.txt /tmp/osi-field-checker/commit-id.txt
+
       - name: Copy OSI Field Checker FMU
         if: steps.cache-osi-field-checker.outputs.cache-hit != 'true'
         working-directory: sl-1-5-sensor-model-testing/build
         run: cp OSIFieldChecker.fmu /tmp/osi-field-checker/OSIFieldChecker.fmu
+
+      - name: esmini Commit ID
+        working-directory: /tmp/osi-field-checker
+        run: echo $(cat commit-id.txt)

--- a/.github/workflows/build_osi_field_checker.yml
+++ b/.github/workflows/build_osi_field_checker.yml
@@ -61,7 +61,7 @@ jobs:
         run: mkdir /tmp/osi-field-checker
 
       - name: Copy Commit ID to Cache
-        if: steps.cache-esmini-fmu.outputs.cache-hit != 'true'
+        if: steps.cache-osi-field-checker.outputs.cache-hit != 'true'
         working-directory: sl-1-5-sensor-model-testing
         run: |
           git rev-parse --short HEAD > commit-id.txt

--- a/.github/workflows/build_tracefile_player.yml
+++ b/.github/workflows/build_tracefile_player.yml
@@ -60,7 +60,20 @@ jobs:
         working-directory: osi-trace-file-player/build
         run: mkdir /tmp/tracefile_fmu
 
+      - name: Copy Commit ID to Cache
+        if: steps.cache-tracefile-fmu.outputs.cache-hit != 'true'
+        working-directory: osi-trace-file-player
+        run: |
+          git rev-parse --short HEAD > commit-id.txt
+          cp commit-id.txt /tmp/tracefile_fmu/commit-id.txt
+
       - name: Copy Tracefile FMU
         if: steps.cache-tracefile-fmu.outputs.cache-hit != 'true'
         working-directory: osi-trace-file-player/build
         run: cp src/OSMPTraceFilePlayer.fmu /tmp/tracefile_fmu/OSMPTraceFilePlayer.fmu
+
+      - name: Commit ID
+        working-directory: /tmp/tracefile_fmu
+        run: |
+          echo "Commit ID: "
+          echo $(cat commit-id.txt)

--- a/.github/workflows/fmu_checker.yml
+++ b/.github/workflows/fmu_checker.yml
@@ -40,3 +40,9 @@ jobs:
     - name: Run FMUComplianceChecker
       working-directory: /tmp/FMUComplianceChecker/build
       run: ./fmuCheck.linux64 /tmp/model_fmu/${{ github.event.repository.name }}.fmu
+
+    - name: Commit ID
+      working-directory: /tmp/FMUComplianceChecker
+      run: |
+        echo "Commit ID: "
+        echo $(git rev-parse --short HEAD)

--- a/.github/workflows/srmd-validator.yml
+++ b/.github/workflows/srmd-validator.yml
@@ -24,3 +24,9 @@ jobs:
     - name: Validate SRMD
       working-directory: sl-1-5-sensor-model-testing/src/srmd-validator
       run: python3 srmd-validator.py
+
+    - name: Commit ID
+      working-directory: sl-1-5-sensor-model-testing
+      run: |
+        echo "Commit ID: "
+        echo $(git rev-parse --short HEAD)


### PR DESCRIPTION
**Reference to a related issue in the repository**
#43 

**Add a description**
Add the commit id of tools utilized in the pipeline as an output. This ensures traceability of the used tools.

- [x] esmini
- [x] OpenMCx
- [x] OSI Field Checker
- [x] Tracefile Player
- [x] FMU Checker
- [x] SRMD Validator

**Take this checklist as orientation for yourself, if this PR is ready for Maintainer Review**
- [x] My suggestion follows the [governance rules](https://github.com/openMSL/governance-and-documentation).
- [x] All commits of this PR are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] My changes generate no errors when passing CI tests. 
- [ ] I updated all documentation (readmes incl. figures) according to my changes.
  -> No documentation necessary
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.
