### PR TITLE
Add protobuf to fmu checker workflow

### DIFF
--- a/.github/workflows/fmu_checker.yml
+++ b/.github/workflows/fmu_checker.yml
@@ -16,6 +16,26 @@ jobs:
         path: /tmp/model_fmu
         key: ${{ runner.os }}-model-fmu-${{ github.sha }}
 
+    - name: Cache Protobuf
+      id: cache-protobuf
+      uses: actions/cache@v3
+      with:
+        path: protobuf-21.12
+        key: ${{ runner.os }}-protobuf
+
+    - name: Download ProtoBuf
+      if: steps.cache-protobuf.outputs.cache-hit != 'true'
+      run: curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protobuf-all-21.12.tar.gz && tar xzvf protobuf-all-21.12.tar.gz
+
+    - name: Build ProtoBuf
+      if: steps.cache-protobuf.outputs.cache-hit != 'true'
+      working-directory: protobuf-21.12
+      run: ./configure DIST_LANG=cpp --disable-shared CXXFLAGS="-fPIC" && make -j4
+
+    - name: Install ProtoBuf
+      working-directory: protobuf-21.12
+      run: sudo make install && sudo ldconfig
+
     - name: Cache FMUComplianceChecker
       id: cache-fmu-checker
       uses: actions/cache@v3


### PR DESCRIPTION
**Add a description**
The fmu checker needs protobuf. It probably only worked before due to caching.

**Take this checklist as orientation for yourself, if this PR is ready for Maintainer Review**
- [x] My suggestion follows the [governance rules](https://github.com/openMSL/governance-and-documentation).
- [x] All commits of this PR are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] My changes generate no errors when passing CI tests. 
- [x] I updated all documentation (readmes incl. figures) according to my changes.
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.
