### PR TITLE
Fix trace file player and trace file writer in pipeline

### DIFF
--- a/.github/workflows/build_tracefile_player.yml
+++ b/.github/workflows/build_tracefile_player.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Copy Tracefile FMU
         if: steps.cache-tracefile-player-fmu.outputs.cache-hit != 'true'
         working-directory: sl-5-5-osi-trace-file-player/build
-        run: cp src/OSMPTraceFilePlayer.fmu /tmp/tracefile_player_fmu/OSMPTraceFilePlayer.fmu
+        run: cp OSMPTraceFilePlayer.fmu /tmp/tracefile_player_fmu/OSMPTraceFilePlayer.fmu
 
       - name: Commit ID
         working-directory: /tmp/tracefile_player_fmu

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ What inputs does the model need and what outputs does it generate?
 <br><br>
 
 < Eye-catcher Image >
-<img src="doc/img/model_video.gif" width="800" />
+<img src="doc/img/model_video.gif" alt="Eye-catcher Image" width="800" />
 
 ## State of the Art
 

--- a/test/integration/004_tracefile_analysis/SystemStructure.ssd
+++ b/test/integration/004_tracefile_analysis/SystemStructure.ssd
@@ -81,15 +81,15 @@
             </ssd:Component>
             <ssd:Component type="application/x-fmu-sharedlibrary" source="/tmp/tracefile_writer_fmu/osi-trace-file-writer.fmu" implementation="CoSimulation" name="osi-trace-file-writer" description="Write binary OSI SensorData trace files">
                 <ssd:Connectors>
-                    <ssd:Connector name="OSMPSensorDataIn.size" kind="input">
+                    <ssd:Connector name="OSIIn.size" kind="input">
                         <ssc:Integer/>
                         <ssd:ConnectorGeometry x="0.0" y="0.25"/>
                     </ssd:Connector>
-                    <ssd:Connector name="OSMPSensorDataIn.base.hi" kind="input">
+                    <ssd:Connector name="OSIIn.base.hi" kind="input">
                         <ssc:Integer/>
                         <ssd:ConnectorGeometry x="0.0" y="0.5"/>
                     </ssd:Connector>
-                    <ssd:Connector name="OSMPSensorDataIn.base.lo" kind="input">
+                    <ssd:Connector name="OSIIn.base.lo" kind="input">
                         <ssc:Integer/>
                         <ssd:ConnectorGeometry x="0.0" y="0.75"/>
                     </ssd:Connector>
@@ -109,6 +109,9 @@
                                     <ssv:Parameter name="custom_name" description="">
                                         <ssv:String value="004_tracefile_analysis"/>
                                     </ssv:Parameter>
+                                    <ssv:Parameter name="type" description="">
+                                        <ssv:String value="sd"/>
+                                    </ssv:Parameter>
                                 </ssv:Parameters>
                             </ssv:ParameterSet>
                         </ssd:ParameterValues>
@@ -120,9 +123,9 @@
             <ssd:Connection startElement="OSMPTraceFilePlayer" startConnector="OSMPSensorViewOut.base.hi" endElement="SensorModel" endConnector="OSMPSensorViewIn.base.hi" suppressUnitConversion="false"/>
             <ssd:Connection startElement="OSMPTraceFilePlayer" startConnector="OSMPSensorViewOut.size" endElement="SensorModel" endConnector="OSMPSensorViewIn.size" suppressUnitConversion="false"/>
             <ssd:Connection startElement="OSMPTraceFilePlayer" startConnector="OSMPSensorViewOut.base.lo" endElement="SensorModel" endConnector="OSMPSensorViewIn.base.lo" suppressUnitConversion="false"/>
-            <ssd:Connection startElement="SensorModel" startConnector="OSMPSensorDataOut.base.hi" endElement="osi-trace-file-writer" endConnector="OSMPSensorDataIn.base.hi" suppressUnitConversion="false"/>
-            <ssd:Connection startElement="osi-trace-file-writer" startConnector="OSMPSensorDataIn.base.lo" endElement="SensorModel" endConnector="OSMPSensorDataOut.base.lo" suppressUnitConversion="false"/>
-            <ssd:Connection startElement="SensorModel" startConnector="OSMPSensorDataOut.size" endElement="osi-trace-file-writer" endConnector="OSMPSensorDataIn.size" suppressUnitConversion="false"/>
+            <ssd:Connection startElement="SensorModel" startConnector="OSMPSensorDataOut.base.hi" endElement="osi-trace-file-writer" endConnector="OSIIn.base.hi" suppressUnitConversion="false"/>
+            <ssd:Connection startElement="osi-trace-file-writer" startConnector="OSIIn.base.lo" endElement="SensorModel" endConnector="OSMPSensorDataOut.base.lo" suppressUnitConversion="false"/>
+            <ssd:Connection startElement="SensorModel" startConnector="OSMPSensorDataOut.size" endElement="osi-trace-file-writer" endConnector="OSIIn.size" suppressUnitConversion="false"/>
         </ssd:Connections>
         <ssd:SystemGeometry x1="-619.0" y1="-666.5" x2="1849.5" y2="126.5"/>
     </ssd:System>


### PR DESCRIPTION
**Add a description**
- The trace file player FMU install directory was updated in the trace file player repo. The FMU location is updated with this PR.
- The trace file writer input parameters were renamed.
- Add alternate text to readme images, as this is a new rule for the markdown linter.

**Take this checklist as orientation for yourself, if this PR is ready for Maintainer Review**
- [x] My suggestion follows the [governance rules](https://openmsl.github.io/doc/OpenMSL/organization/governance_rules.html).
- [x] All commits of this PR are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] My changes generate no errors when passing CI tests. 
- [x] I updated all documentation (readmes incl. figures) according to my changes.
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.

