### PR TITLE
Update add_to_project.yml

### DIFF
--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types:
       - opened
-  pull_request:
+  pull_request_target:
     types:
       - opened
 

--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -7,13 +7,21 @@ on:
   pull_request_target:
     types:
       - opened
+      - synchronize
+      - reopened
 
 jobs:
   add-to-project:
     name: Add issue or pull request to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+      - name: Add to project
+        uses: actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/openMSL/projects/1
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+

--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types:
       - opened
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize


### PR DESCRIPTION
fixes the error: Input required and not supplied: github-token by running add-to-project

The error applies if somebody contribute via fork to the template

